### PR TITLE
Disabling config handler for development 

### DIFF
--- a/lib/config/swCombineViewConfigHandler.class.php
+++ b/lib/config/swCombineViewConfigHandler.class.php
@@ -32,7 +32,11 @@ class swCombineViewConfigHandler extends sfViewConfigHandler
    */
   protected function addHtmlAsset($viewName = '')
   {
-    
+		// Disable for dev environment
+		if (sfConfig::get('sf_debug') || sfConfig::get('sf_test')) {
+			return parent::addHtmlAsset($viewName);
+		}
+
     // Merge the current view's stylesheets with the app's default stylesheets
     $stylesheets = $this->mergeConfigValue('stylesheets', $viewName);
     


### PR DESCRIPTION
Simple fix that works. Needs to be changed when adding support for custom css syntax parser (SASS/LESSC)
