### PR TITLE
added support for gzip compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Doing so, the user agent will not do any extras requests to the webserver.
  * regenerate the combined css and js files with 
 
          ./symfony sw:combine frontend
-         ./symfony sw:combi"e backend
+         ./symfony sw:combine backend
 
 
 ## Enabling Gzip compression
@@ -194,13 +194,13 @@ If your server doesn't have mod_deflate enabled, you can tell the plugin to gzip
 
  * the filename format for combined assets in `APP/config/config_handlers.yml` must end with ".js" or ".css"
 
-    modules/*/config/view.yml:
-      param:
-        configuration:
-          javascript:
-            filename: %s.js
-          stylesheet:
-            filename: %s.css
+        modules/*/config/view.yml:
+          param:
+            configuration:
+              javascript:
+                filename: %s.js
+              stylesheet:
+                filename: %s.css
 
  * edit your `app.yml` file by adding these lines 
 
@@ -210,40 +210,40 @@ If your server doesn't have mod_deflate enabled, you can tell the plugin to gzip
 
  * regenerate the combined css and js files with 
 
-    ./symfony sw:combine frontend
-    ./symfony sw:combine backend
+        ./symfony sw:combine frontend
+        ./symfony sw:combine backend
 
  * add the following lines to your .htacces file (a sample file which combines this with the symfony default htacces is provided in the plugin under data/htaccess.sample)
 
-    <IfModule mod_rewrite.c>
-      RewriteEngine On
+        <IfModule mod_rewrite.c>
+          RewriteEngine On
 
-      # Rules to correctly serve gzip compressed CSS and JS files.
-      # Requires both mod_rewrite and mod_headers to be enabled.
-      <IfModule mod_headers.c>
-        # Serve gzip compressed CSS files if they exist and the client accepts gzip.
-        RewriteCond %{HTTP:Accept-encoding} gzip
-        RewriteCond %{REQUEST_FILENAME}\.gz -s
-        RewriteRule ^(.*)\.css $1\.css\.gz [QSA]
+          # Rules to correctly serve gzip compressed CSS and JS files.
+          # Requires both mod_rewrite and mod_headers to be enabled.
+          <IfModule mod_headers.c>
+            # Serve gzip compressed CSS files if they exist and the client accepts gzip.
+            RewriteCond %{HTTP:Accept-encoding} gzip
+            RewriteCond %{REQUEST_FILENAME}\.gz -s
+            RewriteRule ^(.*)\.css $1\.css\.gz [QSA]
 
-        # Serve gzip compressed JS files if they exist and the client accepts gzip.
-        RewriteCond %{HTTP:Accept-encoding} gzip
-        RewriteCond %{REQUEST_FILENAME}\.gz -s
-        RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
+            # Serve gzip compressed JS files if they exist and the client accepts gzip.
+            RewriteCond %{HTTP:Accept-encoding} gzip
+            RewriteCond %{REQUEST_FILENAME}\.gz -s
+            RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
 
-        # Serve correct content types, and prevent mod_deflate double gzip.
-        RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
-        RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
+            # Serve correct content types, and prevent mod_deflate double gzip.
+            RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
+            RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
 
-        <FilesMatch "(\.js\.gz|\.css\.gz)$">
-          # Serve correct encoding type.
-          Header set Content-Encoding gzip
-          # Force proxies to cache gzipped & non-gzipped css/js files separately.
-          Header append Vary Accept-Encoding
-        </FilesMatch>
-      </IfModule>
+            <FilesMatch "(\.js\.gz|\.css\.gz)$">
+              # Serve correct encoding type.
+              Header set Content-Encoding gzip
+              # Force proxies to cache gzipped & non-gzipped css/js files separately.
+              Header append Vary Accept-Encoding
+            </FilesMatch>
+          </IfModule>
 
-    </IfModule>
+        </IfModule>
 
          
          

--- a/config/htaccess.sample
+++ b/config/htaccess.sample
@@ -1,0 +1,28 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+
+  # Rules to correctly serve gzip compressed CSS and JS files.
+  # Requires both mod_rewrite and mod_headers to be enabled.
+  <IfModule mod_headers.c>
+    # Serve gzip compressed CSS files if they exist and the client accepts gzip.
+    RewriteCond %{HTTP:Accept-encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -s
+    RewriteRule ^(.*)\.css $1\.css\.gz [QSA]
+
+    # Serve gzip compressed JS files if they exist and the client accepts gzip.
+    RewriteCond %{HTTP:Accept-encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -s
+    RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
+
+    # Serve correct content types, and prevent mod_deflate double gzip.
+    RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
+    RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
+
+    <FilesMatch "(\.js\.gz|\.css\.gz)$">
+      # Serve correct encoding type.
+      Header append Content-Encoding gzip
+      # Force proxies to cache gzipped & non-gzipped css/js files separately.
+      Header append Vary Accept-Encoding
+    </FilesMatch>
+  </IfModule>
+</IfModule>

--- a/data/htaccess.sample
+++ b/data/htaccess.sample
@@ -1,5 +1,6 @@
 <IfModule mod_rewrite.c>
   RewriteEngine On
+  RewriteBase /
 
   # Rules to correctly serve gzip compressed CSS and JS files.
   # Requires both mod_rewrite and mod_headers to be enabled.
@@ -20,9 +21,29 @@
 
     <FilesMatch "(\.js\.gz|\.css\.gz)$">
       # Serve correct encoding type.
-      Header append Content-Encoding gzip
+      Header set Content-Encoding gzip
       # Force proxies to cache gzipped & non-gzipped css/js files separately.
       Header append Vary Accept-Encoding
     </FilesMatch>
   </IfModule>
+
+  # we skip all files with .something
+  RewriteCond %{REQUEST_URI} \.(css|js|png|gif|jpg)$
+  RewriteRule .* - [L] 
+
+  # remove trailing slash
+  RewriteCond %{REQUEST_FILENAME} !-d 
+  RewriteCond %{REQUEST_URI} ^(.*)/$
+  RewriteRule ^(.*)/$ $1 [R=301,L]
+
+  # we check if the .html version is here (caching)
+  RewriteRule ^$ index.html [QSA]
+  RewriteRule ^([^.]+)$ $1.html [QSA]
+  RewriteCond %{REQUEST_FILENAME} !-f 
+
+  # no, so we redirect to our front web controller
+  RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+
+# big crash from our front web controller
+ErrorDocument 500 "<h2>Application error</h2>symfony application failed to start properly"

--- a/lib/config/swCombineViewConfigHandler.class.php
+++ b/lib/config/swCombineViewConfigHandler.class.php
@@ -322,14 +322,9 @@ class swCombineViewConfigHandler extends sfViewConfigHandler
     sort($assets);
     
     // compute the name
-    $name =  sprintf( $format, md5(serialize($assets)) );
+    $name =  md5(serialize($assets));
 
-    $params = sfConfig::get('app_swToolbox_swCombine', array('use_gzip' => false));
-    if($params['use_gzip'])
-    {
-      $name .= '.gz';
-    }
-    return $name;
+    return sprintf($format, $name);
   }
   
   public function getPackageName($type, $name)
@@ -343,12 +338,8 @@ class swCombineViewConfigHandler extends sfViewConfigHandler
       md5(sfInflector::underscore('package_'.$type.'_'.$name))
     );
 
-    $params = sfConfig::get('app_swToolbox_swCombine', array('use_gzip' => false));
-    if($params['use_gzip'])
-    {
-      $name .= '.gz';
-    }
-    return $name;
+    $name = md5(sfInflector::underscore('package_'.$type.'_'.$name));
+    return sprintf($format, $name);
   }
   
   /**

--- a/lib/config/swCombineViewConfigHandler.class.php
+++ b/lib/config/swCombineViewConfigHandler.class.php
@@ -322,9 +322,14 @@ class swCombineViewConfigHandler extends sfViewConfigHandler
     sort($assets);
     
     // compute the name
-    $name =  md5(serialize($assets));
+    $name =  sprintf( $format, md5(serialize($assets)) );
 
-    return sprintf($format, $name);
+    $params = sfConfig::get('app_swToolbox_swCombine', array('use_gzip' => false));
+    if($params['use_gzip'])
+    {
+      $name .= '.gz';
+    }
+    return $name;
   }
   
   public function getPackageName($type, $name)
@@ -332,9 +337,18 @@ class swCombineViewConfigHandler extends sfViewConfigHandler
     $configuration = $this->getParameterHolder()->get('configuration');
     $format  = isset($configuration[$type]['filename']) ? $configuration[$type]['filename'] : '%s';
     
-    $name    = md5(sfInflector::underscore('package_'.$type.'_'.$name));
-    
-    return sprintf($format, $name);
+    // compute the name
+    $name =  sprintf(
+      $format,
+      md5(sfInflector::underscore('package_'.$type.'_'.$name))
+    );
+
+    $params = sfConfig::get('app_swToolbox_swCombine', array('use_gzip' => false));
+    if($params['use_gzip'])
+    {
+      $name .= '.gz';
+    }
+    return $name;
   }
   
   /**

--- a/lib/task/swOptimizeCreateFilesTask.class.php
+++ b/lib/task/swOptimizeCreateFilesTask.class.php
@@ -294,6 +294,12 @@ class swOptimizeCreateFilesTask extends sfBaseTask
       $private_path, 
       $force_name_to ? $force_name_to : $this->view_handler->getCombinedName($type, $combine->getFiles())
     );
+
+    $params = sfConfig::get('app_swToolbox_swCombine', array('use_gzip' => false));
+    if ($params['use_gzip'])
+    {
+      $path = str_replace('.gz','',$path);
+    }
     
     if(is_file($path))
     {
@@ -322,7 +328,14 @@ class swOptimizeCreateFilesTask extends sfBaseTask
     $results = $driver->getResults();
 
     $this->logSection('file+', sprintf(' > %s', $force_name_to ? $force_name_to : $this->view_handler->getCombinedName($type, $combine->getFiles())));
-    
+
+    if($params['use_gzip'])
+    {
+      $this->saveContents($path.'.gz', gzencode(file_get_contents($path), 9));
+      $results['optimizedSize'] = filesize($path.'.gz');
+      $results['ratio'] = round($results['optimizedSize']*100/$results['originalSize'],2); 
+    }
+
     $this->logSection('optimize', sprintf(' > from %.2fKB to %.2fKB, ratio -%s%%', 
       $results['originalSize'] / 1024, 
       $results['optimizedSize'] / 1024, 

--- a/lib/task/swOptimizeCreateFilesTask.class.php
+++ b/lib/task/swOptimizeCreateFilesTask.class.php
@@ -294,12 +294,6 @@ class swOptimizeCreateFilesTask extends sfBaseTask
       $private_path, 
       $force_name_to ? $force_name_to : $this->view_handler->getCombinedName($type, $combine->getFiles())
     );
-
-    $params = sfConfig::get('app_swToolbox_swCombine', array('use_gzip' => false));
-    if ($params['use_gzip'])
-    {
-      $path = str_replace('.gz','',$path);
-    }
     
     if(is_file($path))
     {
@@ -329,6 +323,7 @@ class swOptimizeCreateFilesTask extends sfBaseTask
 
     $this->logSection('file+', sprintf(' > %s', $force_name_to ? $force_name_to : $this->view_handler->getCombinedName($type, $combine->getFiles())));
 
+    $params = sfConfig::get('app_swToolbox_swCombine', array('use_gzip' => false));
     if($params['use_gzip'])
     {
       $this->saveContents($path.'.gz', gzencode(file_get_contents($path), 9));


### PR DESCRIPTION
This commit adds gzip compression to the combined/minified assets.
If `app_swToolbox_swCombine_use_gzip` is true, each file is saved in both normal and gzipped version.
The provided sample htaccess file enables the server to serve the corresponding assets with the correct headers,
and voilà, your assets gzipped without mod_deflate !

The implementation is a bit hacky but you get the idea...
